### PR TITLE
Fix type error when special character is included

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,10 @@ import { JSONLoader } from './components/JSONLoader'
 import { JSONInspector } from './components/JSONInspector'
 import { JSONExplorer } from './components/JSONExplorer'
 import { ReactorEditor } from './components/ReactorEditor'
-import { useUpdateMonacoTsTypes } from './logic/useUpdateMonacoTsTypes'
 
 function App() {
   const [json, setJson] = useState<any>()
   const [processedJson, setProcessedJson] = useState<any>()
-
-  useUpdateMonacoTsTypes(json)
 
   return (
     <main className="container">

--- a/src/components/ReactorEditor/index.tsx
+++ b/src/components/ReactorEditor/index.tsx
@@ -2,7 +2,8 @@ import classNames from 'classnames/bind'
 import styles from './ReactorEditor.module.css'
 import { useRef, useState, useEffect } from 'react'
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
-import { JsWorkerSuccess } from './types'
+import { useUpdateMonacoTsTypes } from '@src/logic/useUpdateMonacoTsTypes'
+import type { JsWorkerSuccess } from './types'
 import { useProessJson } from './useProcessJson'
 
 const cx = classNames.bind(styles)
@@ -21,6 +22,8 @@ export function ReactorEditor({ json, onSuccess }: Props) {
   const [editor, setEditor] =
     useState<monaco.editor.IStandaloneCodeEditor | null>(null)
   const monacoDOM = useRef<HTMLDivElement>(null)
+
+  useUpdateMonacoTsTypes(json)
 
   useEffect(() => {
     if (monacoDOM) {

--- a/src/components/ReactorEditor/useProcessJson.ts
+++ b/src/components/ReactorEditor/useProcessJson.ts
@@ -2,6 +2,7 @@ import * as monaco from 'monaco-editor'
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { debounce } from '@src/logic/shared/debounce'
 import { useTunnel } from '@src/logic/shared/useTunnel'
+import { escapeForTypeScript } from '@src/logic/tsType/escape'
 import type { JsWorkerProtocol, JsWorkerSuccess } from './types'
 import { JsWorkerMessageType } from './consts'
 import { useJsWorker } from './useJsWorker'
@@ -82,7 +83,7 @@ function createJsProcessor(model: monaco.editor.ITextModel | null | undefined) {
       type: '${JsWorkerMessageType.TransformResult}',
       result: transform(${
         typeof targetValue === 'object'
-          ? `JSON.parse('${JSON.stringify(targetValue).replaceAll("'", "\\'")}')`
+          ? `JSON.parse('${escapeForTypeScript(JSON.stringify(targetValue))}')`
           : renderPrimitiveValue(targetValue)
       })
     })
@@ -106,7 +107,7 @@ function renderPrimitiveValue(value: any) {
   }
 
   if (typeof value === 'string') {
-    return `'${value.replaceAll("'", "\\'")}'`
+    return `'${escapeForTypeScript(value)}'`
   }
 
   if (typeof value === 'number' || typeof value === 'boolean') {

--- a/src/logic/tsType/escape.test.ts
+++ b/src/logic/tsType/escape.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { escapeForTypeScript } from './escape'
+
+describe('escapeType', () => {
+  it('should escape single quote character', () => {
+    expect(escapeForTypeScript("'")).toBe("\\'")
+  })
+
+  it('should not escape general escape sequence', () => {
+    expect(escapeForTypeScript('\n')).toBe('\\n')
+    expect(escapeForTypeScript("\\'")).toBe("\\\\\\'")
+    expect(escapeForTypeScript('\\')).toBe('\\\\')
+  })
+})

--- a/src/logic/tsType/escape.ts
+++ b/src/logic/tsType/escape.ts
@@ -1,0 +1,16 @@
+/**
+ * Escape single quote and control characters to render properly to TypeScript
+ * @param s
+ * @returns safely cleansed type string
+ */
+export function escapeForTypeScript(s: string) {
+  return s
+    .replaceAll('\\', '\\\\')
+    .replaceAll("'", "\\'")
+    .replaceAll('\b', '\\b')
+    .replaceAll('\f', '\\f')
+    .replaceAll('\n', '\\n')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\t', '\\t')
+    .replaceAll('\v', '\\v')
+}

--- a/src/logic/useUpdateMonacoTsTypes.ts
+++ b/src/logic/useUpdateMonacoTsTypes.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from 'react'
+import { useLayoutEffect, useMemo } from 'react'
 import * as monaco from 'monaco-editor'
 import { renderTsType } from './tsType/render'
 import { extractTsType } from './tsType/extract'
@@ -8,20 +8,22 @@ type PrimitiveOrArrayOrObject = undefined | null | boolean | number | string | P
 type ValidReactor = (data: Type) => PrimitiveOrArrayOrObject`
 
 export function useUpdateMonacoTsTypes(json: any) {
-  useLayoutEffect(() => {
-    if (json === undefined) {
-      monaco.languages.typescript.typescriptDefaults.setExtraLibs([
-        {
-          content: 'type Type = undefined' + ROOT_FUNCTION_TYPE,
-        },
-      ])
-      return
-    }
+  const renderedTypes = useMemo(() => renderFinalType(json), [json])
 
+  useLayoutEffect(() => {
     monaco.languages.typescript.typescriptDefaults.setExtraLibs([
       {
-        content: renderTsType(extractTsType(json)) + ROOT_FUNCTION_TYPE,
+        content: renderedTypes,
       },
     ])
-  }, [json])
+  }, [renderedTypes])
+
+  return renderedTypes
+}
+
+function renderFinalType(json: any) {
+  if (json === undefined) {
+    return 'type Type = undefined' + ROOT_FUNCTION_TYPE
+  }
+  return renderTsType(extractTsType(json)) + ROOT_FUNCTION_TYPE
 }


### PR DESCRIPTION
- When there is `'` or `\` character(s) inside of string literal, the generated type is broken.
- To fix this I implemented specialized clenase logic with simple test