### PR TITLE
Fix #12 - Guard runtime error of `RegExp` search mode

### DIFF
--- a/src/components/JSONInspector/JSONSearch.tsx
+++ b/src/components/JSONInspector/JSONSearch.tsx
@@ -167,23 +167,42 @@ function searchFromLine({
   isMatchWord,
   isRegexUsed,
 }: SearchFromLineParams) {
+  const regexp = createRegExp(isRegexUsed, keyword, isMatchWord, isMatchCase)
+
+  if (!regexp) return []
+
   return line.tokens
     .map((token) => {
       const target = token.content
-      const escapedKeyword = isRegexUsed
-        ? keyword
-        : keyword.replaceAll(/([.?!()\[\]*])/g, '\\$1')
 
-      const regexp = new RegExp(
-        isMatchWord ? `(?<!\\w)${escapedKeyword}(?!\\w)` : escapedKeyword,
-        !isMatchCase ? 'i' : undefined,
-      )
       return {
         token,
         match: regexp.exec(target)!,
       }
     })
     .filter(({ match }) => match)
+}
+
+function createRegExp(
+  isRegexUsed: boolean,
+  keyword: string,
+  isMatchWord: boolean,
+  isMatchCase: boolean,
+) {
+  const escapedKeyword = isRegexUsed
+    ? keyword
+    : keyword.replaceAll(/([.?!()\[\]*])/g, '\\$1')
+
+  try {
+    const regexp = new RegExp(
+      isMatchWord ? `(?<!\\w)${escapedKeyword}(?!\\w)` : escapedKeyword,
+      !isMatchCase ? 'i' : undefined,
+    )
+
+    return regexp
+  } catch (e) {
+    return undefined
+  }
 }
 
 function extractResult(match: RegExpExecArray) {

--- a/src/components/JSONInspector/JSONSearch.tsx
+++ b/src/components/JSONInspector/JSONSearch.tsx
@@ -39,7 +39,7 @@ export function JSONSearch({}: Props) {
           isRegexUsed,
         })
 
-        if (!matchResults.length) return []
+        if (!matchResults.length) return matchResults as []
 
         return matchResults.flatMap(({ token, match }) =>
           extractResult(match).map(

--- a/src/components/JSONInspector/JSONSearch/index.tsx
+++ b/src/components/JSONInspector/JSONSearch/index.tsx
@@ -1,9 +1,9 @@
 import cnx from 'classnames/bind'
-import styles from './JSONInspector.module.css'
+import styles from '../JSONInspector.module.css'
 import { type ChangeEvent, useLayoutEffect, useState } from 'react'
-import { useJSONInspector } from './JSONInspectorContext'
-import type { IndexedJSONLine } from './JSONRenderer/types'
-import type { JSONSearchResult } from './types'
+import { useJSONInspector } from '../JSONInspectorContext'
+import type { IndexedJSONLine } from '../JSONRenderer/types'
+import type { JSONSearchResult } from '../types'
 
 const cx = cnx.bind(styles)
 

--- a/src/components/JSONInspector/JSONSearch/index.tsx
+++ b/src/components/JSONInspector/JSONSearch/index.tsx
@@ -2,8 +2,8 @@ import cnx from 'classnames/bind'
 import styles from '../JSONInspector.module.css'
 import { type ChangeEvent, useLayoutEffect, useState } from 'react'
 import { useJSONInspector } from '../JSONInspectorContext'
-import type { IndexedJSONLine } from '../JSONRenderer/types'
 import type { JSONSearchResult } from '../types'
+import { extractResult, searchFromLine } from './logic'
 
 const cx = cnx.bind(styles)
 
@@ -150,75 +150,4 @@ export function JSONSearch({}: Props) {
       </button>
     </fieldset>
   )
-}
-
-type SearchFromLineParams = {
-  line: IndexedJSONLine
-  keyword: string
-  isMatchCase: boolean
-  isMatchWord: boolean
-  isRegexUsed: boolean
-}
-
-function searchFromLine({
-  line,
-  keyword,
-  isMatchCase,
-  isMatchWord,
-  isRegexUsed,
-}: SearchFromLineParams) {
-  const regexp = createRegExp(isRegexUsed, keyword, isMatchWord, isMatchCase)
-
-  if (!regexp) return []
-
-  return line.tokens
-    .map((token) => {
-      const target = token.content
-
-      return {
-        token,
-        match: regexp.exec(target)!,
-      }
-    })
-    .filter(({ match }) => match)
-}
-
-function createRegExp(
-  isRegexUsed: boolean,
-  keyword: string,
-  isMatchWord: boolean,
-  isMatchCase: boolean,
-) {
-  const escapedKeyword = isRegexUsed
-    ? keyword
-    : keyword.replaceAll(/([.?!()\[\]*])/g, '\\$1')
-
-  try {
-    const regexp = new RegExp(
-      isMatchWord ? `(?<!\\w)${escapedKeyword}(?!\\w)` : escapedKeyword,
-      !isMatchCase ? 'i' : undefined,
-    )
-
-    return regexp
-  } catch (e) {
-    return undefined
-  }
-}
-
-function extractResult(match: RegExpExecArray) {
-  if (match.length === 1) {
-    return [[match.index, match.index + match[0].length]]
-  }
-
-  const results: [number, number][] = []
-
-  for (let i = 1; i <= match.length - 1; ++i) {
-    const matchedIndices = match.indices?.[i]
-
-    if (matchedIndices) {
-      results.push(matchedIndices)
-    }
-  }
-
-  return results
 }

--- a/src/components/JSONInspector/JSONSearch/index.tsx
+++ b/src/components/JSONInspector/JSONSearch/index.tsx
@@ -29,36 +29,38 @@ export function JSONSearch({}: Props) {
       return
     }
 
-    const matchedLines = lines
-      .flatMap((line) => {
-        const matchResults = searchFromLine({
-          line,
-          keyword,
-          isMatchCase,
-          isMatchWord,
-          isRegexUsed,
-        })
-
-        if (!matchResults.length) return matchResults as []
-
-        return matchResults.flatMap(({ token, match }) =>
-          extractResult(match).map(
-            ([beginPosInToken, endPosInToken]) =>
-              ({
-                lineIndex: line.index,
-                tokenId: token.id,
-                beginPosInToken,
-                endPosInToken,
-              }) satisfies JSONSearchResult,
-          ),
-        )
+    const matchedLines = lines.flatMap((line) => {
+      const matchResults = searchFromLine({
+        line,
+        keyword,
+        isMatchCase,
+        isMatchWord,
+        isRegexUsed,
       })
-      .filter(Boolean) as JSONSearchResult[]
+
+      if (!matchResults.length) return matchResults as []
+
+      return matchResults
+        .map(({ token, match }) => {
+          const [beginPosInToken, endPosInToken] = extractResult(match)
+
+          if (beginPosInToken === endPosInToken) return undefined!
+
+          return {
+            lineIndex: line.index,
+            tokenId: token.id,
+            beginPosInToken,
+            endPosInToken,
+          } satisfies JSONSearchResult
+        })
+        .filter(Boolean)
+    })
 
     setMatches(matchedLines)
   }
 
   useLayoutEffect(handleSearchOptionChange, [
+    lines,
     keyword,
     isMatchCase,
     isMatchWord,

--- a/src/components/JSONInspector/JSONSearch/logic.ts
+++ b/src/components/JSONInspector/JSONSearch/logic.ts
@@ -1,0 +1,72 @@
+import type { IndexedJSONLine } from '../JSONRenderer/types'
+
+type SearchFromLineParams = {
+  line: IndexedJSONLine
+  keyword: string
+  isMatchCase: boolean
+  isMatchWord: boolean
+  isRegexUsed: boolean
+}
+
+export function searchFromLine({
+  line,
+  keyword,
+  isMatchCase,
+  isMatchWord,
+  isRegexUsed,
+}: SearchFromLineParams) {
+  const regexp = createRegExp(isRegexUsed, keyword, isMatchWord, isMatchCase)
+
+  if (!regexp) return []
+
+  return line.tokens
+    .map((token) => {
+      const target = token.content
+
+      return {
+        token,
+        match: regexp.exec(target)!,
+      }
+    })
+    .filter(({ match }) => match)
+}
+
+function createRegExp(
+  isRegexUsed: boolean,
+  keyword: string,
+  isMatchWord: boolean,
+  isMatchCase: boolean,
+) {
+  const escapedKeyword = isRegexUsed
+    ? keyword
+    : keyword.replaceAll(/([.?!()\[\]*])/g, '\\$1')
+
+  try {
+    const regexp = new RegExp(
+      isMatchWord ? `(?<!\\w)${escapedKeyword}(?!\\w)` : escapedKeyword,
+      !isMatchCase ? 'i' : undefined,
+    )
+
+    return regexp
+  } catch (e) {
+    return undefined
+  }
+}
+
+export function extractResult(match: RegExpExecArray) {
+  if (match.length === 1) {
+    return [[match.index, match.index + match[0].length]]
+  }
+
+  const results: [number, number][] = []
+
+  for (let i = 1; i <= match.length - 1; ++i) {
+    const matchedIndices = match.indices?.[i]
+
+    if (matchedIndices) {
+      results.push(matchedIndices)
+    }
+  }
+
+  return results
+}

--- a/src/components/JSONInspector/JSONSearch/logic.ts
+++ b/src/components/JSONInspector/JSONSearch/logic.ts
@@ -37,11 +37,11 @@ function createRegExp(
   isMatchWord: boolean,
   isMatchCase: boolean,
 ) {
-  const escapedKeyword = isRegexUsed
-    ? keyword
-    : keyword.replaceAll(/([.?!()\[\]*])/g, '\\$1')
-
   try {
+    const escapedKeyword = isRegexUsed
+      ? keyword
+      : escapeStringForRegExp(keyword)
+
     const regexp = new RegExp(
       isMatchWord ? `(?<!\\w)${escapedKeyword}(?!\\w)` : escapedKeyword,
       !isMatchCase ? 'i' : undefined,
@@ -53,20 +53,14 @@ function createRegExp(
   }
 }
 
+/**
+ * Add escape sequence `\` to put string content
+ * safely to `new RegExp`
+ * */
+function escapeStringForRegExp(s: string) {
+  return s.replaceAll(/([.,?!*+$|\^()\[\]{}\\])/g, '\\$1')
+}
+
 export function extractResult(match: RegExpExecArray) {
-  if (match.length === 1) {
-    return [[match.index, match.index + match[0].length]]
-  }
-
-  const results: [number, number][] = []
-
-  for (let i = 1; i <= match.length - 1; ++i) {
-    const matchedIndices = match.indices?.[i]
-
-    if (matchedIndices) {
-      results.push(matchedIndices)
-    }
-  }
-
-  return results
+  return [match.index, match.index + match[0].length]
 }


### PR DESCRIPTION
- #12 
- Move `JSONSearch` into directory and extract utilities from `index.tsx`
- When typing parenthesis (ex: `a(1`) it eventually crashes because it's not a valid RegExp syntax at that time.
- When empty string is matched (ex: `x*`) it crasshes because browser will include `undefined` for matched strings
- Return total matched string instead of individual group, to simplify UX

`i_love_collei`