### PR TITLE
Add indent at each lines in `JsonArranger`

### DIFF
--- a/src/logic/arrangers/JsonArranger.test.ts
+++ b/src/logic/arrangers/JsonArranger.test.ts
@@ -117,7 +117,7 @@ describe('JsonArranger', () => {
           {
             line: 1,
             type: 'line',
-            children: [{ text: '42' }],
+            children: [{ text: '  ' }, { text: '42' }],
           },
           {
             line: 2,
@@ -144,16 +144,86 @@ describe('JsonArranger', () => {
           {
             line: 1,
             type: 'line',
-            children: [{ text: '1' }, { text: ',' }],
+            children: [{ text: '  ' }, { text: '1' }, { text: ',' }],
           },
           {
             line: 2,
             type: 'line',
-            children: [{ text: '2' }],
+            children: [{ text: '  ' }, { text: '2' }],
           },
           {
             line: 3,
             type: 'line',
+            children: [{ text: ']' }],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should arrange nested array with increased indent', () => {
+    expect(JsonArranger.arrange([[[0, 1]]])).toMatchObject<NestedContent[]>([
+      {
+        type: 'block',
+        lineBegin: 0,
+        lineEnd: 7,
+        children: [
+          {
+            type: 'line',
+            line: 0,
+            children: [{ text: '[' }],
+          },
+          {
+            type: 'block',
+            lineBegin: 1,
+            lineEnd: 6,
+            children: [
+              {
+                type: 'line',
+                line: 1,
+                children: [{ text: '  ' }, { text: '[' }],
+              },
+              {
+                type: 'block',
+                lineBegin: 2,
+                lineEnd: 5,
+                children: [
+                  {
+                    type: 'line',
+                    line: 2,
+                    children: [{ text: '    ' }, { text: '[' }],
+                  },
+                  {
+                    type: 'line',
+                    line: 3,
+                    children: [
+                      { text: '      ' },
+                      { text: '0' },
+                      { text: ',' },
+                    ],
+                  },
+                  {
+                    type: 'line',
+                    line: 4,
+                    children: [{ text: '      ' }, { text: '1' }],
+                  },
+                  {
+                    type: 'line',
+                    line: 5,
+                    children: [{ text: '    ' }, { text: ']' }],
+                  },
+                ],
+              },
+              {
+                type: 'line',
+                line: 6,
+                children: [{ text: '  ' }, { text: ']' }],
+              },
+            ],
+          },
+          {
+            type: 'line',
+            line: 7,
             children: [{ text: ']' }],
           },
         ],
@@ -200,7 +270,11 @@ describe('JsonArranger', () => {
           {
             line: 1,
             type: 'line',
-            children: [{ text: '"key": ' }, { text: '"value"' }],
+            children: [
+              { text: '  ' },
+              { text: '"key": ' },
+              { text: '"value"' },
+            ],
           },
           {
             line: 2,
@@ -228,12 +302,17 @@ describe('JsonArranger', () => {
             {
               line: 1,
               type: 'line',
-              children: [{ text: '"a": ' }, { text: '1' }, { text: ',' }],
+              children: [
+                { text: '  ' },
+                { text: '"a": ' },
+                { text: '1' },
+                { text: ',' },
+              ],
             },
             {
               line: 2,
               type: 'line',
-              children: [{ text: '"b": ' }, { text: '2' }],
+              children: [{ text: '  ' }, { text: '"b": ' }, { text: '2' }],
             },
             {
               line: 3,
@@ -274,22 +353,22 @@ describe('JsonArranger', () => {
               {
                 line: 1,
                 type: 'line',
-                children: [{ text: '"a": ' }, { text: '[' }],
+                children: [{ text: '  ' }, { text: '"a": ' }, { text: '[' }],
               },
               {
                 line: 2,
                 type: 'line',
-                children: [{ text: '4' }, { text: ',' }],
+                children: [{ text: '    ' }, { text: '4' }, { text: ',' }],
               },
               {
                 line: 3,
                 type: 'line',
-                children: [{ text: '2' }],
+                children: [{ text: '    ' }, { text: '2' }],
               },
               {
                 line: 4,
                 type: 'line',
-                children: [{ text: ']' }],
+                children: [{ text: '  ' }, { text: ']' }],
               },
             ],
           },
@@ -332,17 +411,17 @@ describe('JsonArranger', () => {
               {
                 line: 1,
                 type: 'line',
-                children: [{ text: '"a": ' }, { text: '{' }],
+                children: [{ text: '  ' }, { text: '"a": ' }, { text: '{' }],
               },
               {
                 line: 2,
                 type: 'line',
-                children: [{ text: '"b": ' }, { text: '1' }],
+                children: [{ text: '    ' }, { text: '"b": ' }, { text: '1' }],
               },
               {
                 line: 3,
                 type: 'line',
-                children: [{ text: '}' }],
+                children: [{ text: '  ' }, { text: '}' }],
               },
             ],
           },
@@ -399,22 +478,22 @@ describe('JsonArranger', () => {
                 {
                   line: 1,
                   type: 'line',
-                  children: [{ text: '"a": ' }, { text: '[' }],
+                  children: [{ text: '  ' }, { text: '"a": ' }, { text: '[' }],
                 },
                 {
                   line: 2,
                   type: 'line',
-                  children: [{ text: '0' }, { text: ',' }],
+                  children: [{ text: '    ' }, { text: '0' }, { text: ',' }],
                 },
                 {
                   line: 3,
                   type: 'line',
-                  children: [{ text: 'true' }],
+                  children: [{ text: '    ' }, { text: 'true' }],
                 },
                 {
                   line: 4,
                   type: 'line',
-                  children: [{ text: ']' }, { text: ',' }],
+                  children: [{ text: '  ' }, { text: ']' }, { text: ',' }],
                 },
               ],
             },
@@ -427,12 +506,13 @@ describe('JsonArranger', () => {
                 {
                   line: 5,
                   type: 'line',
-                  children: [{ text: '"b": ' }, { text: '{' }],
+                  children: [{ text: '  ' }, { text: '"b": ' }, { text: '{' }],
                 },
                 {
                   line: 6,
                   type: 'line',
                   children: [
+                    { text: '    ' },
                     { text: '"c": ' },
                     { text: 'null' },
                     { text: ',' },
@@ -441,12 +521,16 @@ describe('JsonArranger', () => {
                 {
                   line: 7,
                   type: 'line',
-                  children: [{ text: '"d": ' }, { text: '"babo"' }],
+                  children: [
+                    { text: '    ' },
+                    { text: '"d": ' },
+                    { text: '"babo"' },
+                  ],
                 },
                 {
                   line: 8,
                   type: 'line',
-                  children: [{ text: '}' }],
+                  children: [{ text: '  ' }, { text: '}' }],
                 },
               ],
             },

--- a/src/logic/arrangers/JsonArranger.ts
+++ b/src/logic/arrangers/JsonArranger.ts
@@ -25,7 +25,13 @@ function arrangeJson(data: any, offset = 0): JsonArrangerResult {
         type: 'block',
         lineBegin: offset,
         lineEnd: offset,
-        children: [arrangePrimitive(data, offset)],
+        children: [
+          {
+            type: 'line',
+            line: offset,
+            children: [arrangePrimitive(data)],
+          },
+        ],
       },
       nextOffset: offset + 1,
     }
@@ -38,40 +44,41 @@ function arrangeJson(data: any, offset = 0): JsonArrangerResult {
 
 function arrangePrimitive(
   data: boolean | number | string | undefined | null,
-  offset = 0,
-): LineContent {
+): InlineContent {
   return {
-    type: 'line',
-    line: offset,
-    children: [
-      {
-        text: typeof data === 'string' ? `"${data}"` : '' + data,
-      },
-    ],
+    text: typeof data === 'string' ? `"${data}"` : '' + data,
   }
 }
 
-function arrangeArray(data: unknown[], offset = 0): JsonArrangerResult {
+function arrangeArray(
+  data: unknown[],
+  offset = 0,
+  indent = 0,
+): JsonArrangerResult {
   const lineBegin = offset
   const children = [
     {
       type: 'line',
       line: offset,
-      children: [{ text: '[' }],
+      children: [createIndent(indent), { text: '[' }].filter(Boolean),
     },
   ] as (LineContent | NestedContent)[]
   offset += 1
 
   for (let index = 0; index < data.length; ++index) {
-    const { content, nextOffset } = arrangeJsonRaw(data[index], offset)
-    children.push(insertComma(content, index === data.length - 1))
+    const { content, nextOffset } = arrangeJsonRaw(
+      data[index],
+      offset,
+      indent + 1,
+    )
+    children.push(insertComma(content, index === data.length - 1, indent + 1))
     offset = nextOffset
   }
 
   children.push({
     type: 'line',
     line: offset,
-    children: [{ text: ']' }],
+    children: [createIndent(indent)!, { text: ']' }].filter(Boolean),
   })
   offset += 1
 
@@ -89,13 +96,14 @@ function arrangeArray(data: unknown[], offset = 0): JsonArrangerResult {
 function arrangeObject(
   data: Record<string, any>,
   offset = 0,
+  indent = 0,
 ): JsonArrangerResult {
   const lineBegin = offset
   const children = [
     {
       type: 'line',
       line: offset,
-      children: [{ text: '{' }],
+      children: [createIndent(indent), { text: '{' }].filter(Boolean),
     },
   ] as (LineContent | NestedContent)[]
   offset += 1
@@ -103,12 +111,20 @@ function arrangeObject(
   const keys = Object.keys(data)
   for (let index = 0; index < keys.length; ++index) {
     const key = keys[index]
-    const { content, nextOffset } = arrangeJsonRaw(data[key], offset)
+    const { content, nextOffset } = arrangeJsonRaw(
+      data[key],
+      offset,
+      indent + 1,
+    )
     const keyContent = { text: `"${key}": ` }
 
     children.push(
       insertComma(
-        arrangeObjectEntry(content, keyContent),
+        arrangeObjectEntry(
+          removeFirstLineIndent(content),
+          keyContent,
+          indent + 1,
+        ),
         index >= keys.length - 1,
       ),
     )
@@ -118,7 +134,7 @@ function arrangeObject(
   children.push({
     type: 'line',
     line: offset,
-    children: [{ text: '}' }],
+    children: [createIndent(indent)!, { text: '}' }].filter(Boolean),
   })
   offset += 1
 
@@ -133,6 +149,31 @@ function arrangeObject(
   }
 }
 
+function removeFirstLineIndent<T extends NestedContent | LineContent>(
+  content: T,
+): T {
+  if (content.type === 'block') {
+    return {
+      ...content,
+      children: content.children?.map((child, index) =>
+        index === 0 ? removeFirstLineIndent(child) : child,
+      ),
+    }
+  }
+
+  // line
+  const firstIndent = content.children?.findIndex((line) =>
+    line.text.match(/^(?:  )+$/),
+  )
+
+  if (firstIndent === -1) return content
+
+  return {
+    ...content,
+    children: content.children?.filter((_, index) => index !== firstIndent),
+  }
+}
+
 /**
  * Insert comma at the last LineContent of its children
  * If it's the last content, no comma will be inserted
@@ -140,35 +181,48 @@ function arrangeObject(
 function insertComma(
   content: LineContent | NestedContent,
   isLast: boolean,
+  indent = 0,
 ): LineContent | NestedContent {
   if (content.type === 'line') {
-    return insertCommaForLine(content, isLast)
+    return insertCommaForLine(content, isLast, indent)
   }
-  return insertCommaForNested(content, isLast)
+  return insertCommaForNested(content, isLast, indent)
 }
 
 function insertCommaForLine(
   content: LineContent,
   isLast: boolean,
+  indent = 0,
 ): LineContent {
-  if (isLast) return content
+  if (isLast)
+    return {
+      ...content,
+      children: [createIndent(indent)!, ...(content.children ?? [])].filter(
+        Boolean,
+      ),
+    }
 
   return {
     ...content,
-    children: [...(content.children ?? []), { text: ',' }],
+    children: [
+      createIndent(indent)!,
+      ...(content.children ?? []),
+      { text: ',' },
+    ].filter(Boolean),
   }
 }
 
 function insertCommaForNested(
   content: NestedContent,
   isLast: boolean,
+  indent = 0,
 ): NestedContent {
   if (isLast) return content
 
   return {
     ...content,
     children: content.children?.map((child, index, list) =>
-      index === list.length - 1 ? insertComma(child, false) : child,
+      index === list.length - 1 ? insertComma(child, false, indent) : child,
     ),
   }
 }
@@ -176,26 +230,33 @@ function insertCommaForNested(
 function arrangeObjectEntry(
   content: LineContent | NestedContent,
   keyContent: InlineContent,
+  indent = 0,
 ): LineContent | NestedContent {
   if (content.type === 'line') {
-    return arrangeObjectEntryForLine(content, keyContent)
+    return arrangeObjectEntryForLine(content, keyContent, indent)
   }
-  return arrangeObjectEntryForNested(content, keyContent)
+  return arrangeObjectEntryForNested(content, keyContent, indent)
 }
 
 function arrangeObjectEntryForLine(
   content: LineContent,
   keyContent: InlineContent,
+  indent = 0,
 ): LineContent {
   return {
     ...content,
-    children: [keyContent, ...(content.children ?? [])],
+    children: [
+      createIndent(indent)!,
+      keyContent,
+      ...(content.children ?? []),
+    ].filter(Boolean),
   }
 }
 
 function arrangeObjectEntryForNested(
   content: NestedContent,
   keyContent: InlineContent,
+  indent = 0,
 ): NestedContent {
   return {
     type: 'block',
@@ -212,7 +273,11 @@ function arrangeObjectEntryForNested(
             type: 'line',
             line: content.lineBegin,
             // currently children[0] must be bracket
-            children: [keyContent, ...((child as LineContent).children ?? [])],
+            children: [
+              createIndent(indent)!,
+              keyContent,
+              ...((child as LineContent).children ?? []),
+            ].filter(Boolean),
           }
         : child,
     ),
@@ -222,18 +287,31 @@ function arrangeObjectEntryForNested(
 function arrangeJsonRaw(
   data: any,
   offset = 0,
+  indent = 0,
 ): {
   content: LineContent | NestedContent
   nextOffset: number
 } {
   if (!data || typeof data !== 'object') {
     return {
-      content: arrangePrimitive(data, offset),
+      content: {
+        type: 'line',
+        line: offset,
+        children: [arrangePrimitive(data)],
+      },
       nextOffset: offset + 1,
     }
   }
   if (data instanceof Array) {
-    return arrangeArray(data, offset)
+    return arrangeArray(data, offset, indent)
   }
-  return arrangeObject(data, offset)
+  return arrangeObject(data, offset, indent)
+}
+
+function createIndent(indent: number): InlineContent | null {
+  if (!indent) return null
+
+  return {
+    text: ' '.repeat(indent * 2),
+  }
 }


### PR DESCRIPTION
# Related

- #9 
- #23 

# Details

- Add indent at each lines in `JsonArranger` as I forget to handle.
- Since indent is also kind of `InlineContent`, arranger must generate by themselves.
- Add tests for changed codes

`i_love_collei`