### PR TITLE
Revert "Add indent at each lines in `JsonArranger` (#24)"

### DIFF
--- a/src/logic/arrangers/JsonArranger.test.ts
+++ b/src/logic/arrangers/JsonArranger.test.ts
@@ -117,7 +117,7 @@ describe('JsonArranger', () => {
           {
             line: 1,
             type: 'line',
-            children: [{ text: '  ' }, { text: '42' }],
+            children: [{ text: '42' }],
           },
           {
             line: 2,
@@ -144,86 +144,16 @@ describe('JsonArranger', () => {
           {
             line: 1,
             type: 'line',
-            children: [{ text: '  ' }, { text: '1' }, { text: ',' }],
+            children: [{ text: '1' }, { text: ',' }],
           },
           {
             line: 2,
             type: 'line',
-            children: [{ text: '  ' }, { text: '2' }],
+            children: [{ text: '2' }],
           },
           {
             line: 3,
             type: 'line',
-            children: [{ text: ']' }],
-          },
-        ],
-      },
-    ])
-  })
-
-  it('should arrange nested array with increased indent', () => {
-    expect(JsonArranger.arrange([[[0, 1]]])).toMatchObject<NestedContent[]>([
-      {
-        type: 'block',
-        lineBegin: 0,
-        lineEnd: 7,
-        children: [
-          {
-            type: 'line',
-            line: 0,
-            children: [{ text: '[' }],
-          },
-          {
-            type: 'block',
-            lineBegin: 1,
-            lineEnd: 6,
-            children: [
-              {
-                type: 'line',
-                line: 1,
-                children: [{ text: '  ' }, { text: '[' }],
-              },
-              {
-                type: 'block',
-                lineBegin: 2,
-                lineEnd: 5,
-                children: [
-                  {
-                    type: 'line',
-                    line: 2,
-                    children: [{ text: '    ' }, { text: '[' }],
-                  },
-                  {
-                    type: 'line',
-                    line: 3,
-                    children: [
-                      { text: '      ' },
-                      { text: '0' },
-                      { text: ',' },
-                    ],
-                  },
-                  {
-                    type: 'line',
-                    line: 4,
-                    children: [{ text: '      ' }, { text: '1' }],
-                  },
-                  {
-                    type: 'line',
-                    line: 5,
-                    children: [{ text: '    ' }, { text: ']' }],
-                  },
-                ],
-              },
-              {
-                type: 'line',
-                line: 6,
-                children: [{ text: '  ' }, { text: ']' }],
-              },
-            ],
-          },
-          {
-            type: 'line',
-            line: 7,
             children: [{ text: ']' }],
           },
         ],
@@ -270,11 +200,7 @@ describe('JsonArranger', () => {
           {
             line: 1,
             type: 'line',
-            children: [
-              { text: '  ' },
-              { text: '"key": ' },
-              { text: '"value"' },
-            ],
+            children: [{ text: '"key": ' }, { text: '"value"' }],
           },
           {
             line: 2,
@@ -302,17 +228,12 @@ describe('JsonArranger', () => {
             {
               line: 1,
               type: 'line',
-              children: [
-                { text: '  ' },
-                { text: '"a": ' },
-                { text: '1' },
-                { text: ',' },
-              ],
+              children: [{ text: '"a": ' }, { text: '1' }, { text: ',' }],
             },
             {
               line: 2,
               type: 'line',
-              children: [{ text: '  ' }, { text: '"b": ' }, { text: '2' }],
+              children: [{ text: '"b": ' }, { text: '2' }],
             },
             {
               line: 3,
@@ -353,22 +274,22 @@ describe('JsonArranger', () => {
               {
                 line: 1,
                 type: 'line',
-                children: [{ text: '  ' }, { text: '"a": ' }, { text: '[' }],
+                children: [{ text: '"a": ' }, { text: '[' }],
               },
               {
                 line: 2,
                 type: 'line',
-                children: [{ text: '    ' }, { text: '4' }, { text: ',' }],
+                children: [{ text: '4' }, { text: ',' }],
               },
               {
                 line: 3,
                 type: 'line',
-                children: [{ text: '    ' }, { text: '2' }],
+                children: [{ text: '2' }],
               },
               {
                 line: 4,
                 type: 'line',
-                children: [{ text: '  ' }, { text: ']' }],
+                children: [{ text: ']' }],
               },
             ],
           },
@@ -411,17 +332,17 @@ describe('JsonArranger', () => {
               {
                 line: 1,
                 type: 'line',
-                children: [{ text: '  ' }, { text: '"a": ' }, { text: '{' }],
+                children: [{ text: '"a": ' }, { text: '{' }],
               },
               {
                 line: 2,
                 type: 'line',
-                children: [{ text: '    ' }, { text: '"b": ' }, { text: '1' }],
+                children: [{ text: '"b": ' }, { text: '1' }],
               },
               {
                 line: 3,
                 type: 'line',
-                children: [{ text: '  ' }, { text: '}' }],
+                children: [{ text: '}' }],
               },
             ],
           },
@@ -478,22 +399,22 @@ describe('JsonArranger', () => {
                 {
                   line: 1,
                   type: 'line',
-                  children: [{ text: '  ' }, { text: '"a": ' }, { text: '[' }],
+                  children: [{ text: '"a": ' }, { text: '[' }],
                 },
                 {
                   line: 2,
                   type: 'line',
-                  children: [{ text: '    ' }, { text: '0' }, { text: ',' }],
+                  children: [{ text: '0' }, { text: ',' }],
                 },
                 {
                   line: 3,
                   type: 'line',
-                  children: [{ text: '    ' }, { text: 'true' }],
+                  children: [{ text: 'true' }],
                 },
                 {
                   line: 4,
                   type: 'line',
-                  children: [{ text: '  ' }, { text: ']' }, { text: ',' }],
+                  children: [{ text: ']' }, { text: ',' }],
                 },
               ],
             },
@@ -506,13 +427,12 @@ describe('JsonArranger', () => {
                 {
                   line: 5,
                   type: 'line',
-                  children: [{ text: '  ' }, { text: '"b": ' }, { text: '{' }],
+                  children: [{ text: '"b": ' }, { text: '{' }],
                 },
                 {
                   line: 6,
                   type: 'line',
                   children: [
-                    { text: '    ' },
                     { text: '"c": ' },
                     { text: 'null' },
                     { text: ',' },
@@ -521,16 +441,12 @@ describe('JsonArranger', () => {
                 {
                   line: 7,
                   type: 'line',
-                  children: [
-                    { text: '    ' },
-                    { text: '"d": ' },
-                    { text: '"babo"' },
-                  ],
+                  children: [{ text: '"d": ' }, { text: '"babo"' }],
                 },
                 {
                   line: 8,
                   type: 'line',
-                  children: [{ text: '  ' }, { text: '}' }],
+                  children: [{ text: '}' }],
                 },
               ],
             },

--- a/src/logic/arrangers/JsonArranger.ts
+++ b/src/logic/arrangers/JsonArranger.ts
@@ -25,13 +25,7 @@ function arrangeJson(data: any, offset = 0): JsonArrangerResult {
         type: 'block',
         lineBegin: offset,
         lineEnd: offset,
-        children: [
-          {
-            type: 'line',
-            line: offset,
-            children: [arrangePrimitive(data)],
-          },
-        ],
+        children: [arrangePrimitive(data, offset)],
       },
       nextOffset: offset + 1,
     }
@@ -44,41 +38,40 @@ function arrangeJson(data: any, offset = 0): JsonArrangerResult {
 
 function arrangePrimitive(
   data: boolean | number | string | undefined | null,
-): InlineContent {
+  offset = 0,
+): LineContent {
   return {
-    text: typeof data === 'string' ? `"${data}"` : '' + data,
+    type: 'line',
+    line: offset,
+    children: [
+      {
+        text: typeof data === 'string' ? `"${data}"` : '' + data,
+      },
+    ],
   }
 }
 
-function arrangeArray(
-  data: unknown[],
-  offset = 0,
-  indent = 0,
-): JsonArrangerResult {
+function arrangeArray(data: unknown[], offset = 0): JsonArrangerResult {
   const lineBegin = offset
   const children = [
     {
       type: 'line',
       line: offset,
-      children: [createIndent(indent), { text: '[' }].filter(Boolean),
+      children: [{ text: '[' }],
     },
   ] as (LineContent | NestedContent)[]
   offset += 1
 
   for (let index = 0; index < data.length; ++index) {
-    const { content, nextOffset } = arrangeJsonRaw(
-      data[index],
-      offset,
-      indent + 1,
-    )
-    children.push(insertComma(content, index === data.length - 1, indent + 1))
+    const { content, nextOffset } = arrangeJsonRaw(data[index], offset)
+    children.push(insertComma(content, index === data.length - 1))
     offset = nextOffset
   }
 
   children.push({
     type: 'line',
     line: offset,
-    children: [createIndent(indent)!, { text: ']' }].filter(Boolean),
+    children: [{ text: ']' }],
   })
   offset += 1
 
@@ -96,14 +89,13 @@ function arrangeArray(
 function arrangeObject(
   data: Record<string, any>,
   offset = 0,
-  indent = 0,
 ): JsonArrangerResult {
   const lineBegin = offset
   const children = [
     {
       type: 'line',
       line: offset,
-      children: [createIndent(indent), { text: '{' }].filter(Boolean),
+      children: [{ text: '{' }],
     },
   ] as (LineContent | NestedContent)[]
   offset += 1
@@ -111,20 +103,12 @@ function arrangeObject(
   const keys = Object.keys(data)
   for (let index = 0; index < keys.length; ++index) {
     const key = keys[index]
-    const { content, nextOffset } = arrangeJsonRaw(
-      data[key],
-      offset,
-      indent + 1,
-    )
+    const { content, nextOffset } = arrangeJsonRaw(data[key], offset)
     const keyContent = { text: `"${key}": ` }
 
     children.push(
       insertComma(
-        arrangeObjectEntry(
-          removeFirstLineIndent(content),
-          keyContent,
-          indent + 1,
-        ),
+        arrangeObjectEntry(content, keyContent),
         index >= keys.length - 1,
       ),
     )
@@ -134,7 +118,7 @@ function arrangeObject(
   children.push({
     type: 'line',
     line: offset,
-    children: [createIndent(indent)!, { text: '}' }].filter(Boolean),
+    children: [{ text: '}' }],
   })
   offset += 1
 
@@ -149,31 +133,6 @@ function arrangeObject(
   }
 }
 
-function removeFirstLineIndent<T extends NestedContent | LineContent>(
-  content: T,
-): T {
-  if (content.type === 'block') {
-    return {
-      ...content,
-      children: content.children?.map((child, index) =>
-        index === 0 ? removeFirstLineIndent(child) : child,
-      ),
-    }
-  }
-
-  // line
-  const firstIndent = content.children?.findIndex((line) =>
-    line.text.match(/^(?:  )+$/),
-  )
-
-  if (firstIndent === -1) return content
-
-  return {
-    ...content,
-    children: content.children?.filter((_, index) => index !== firstIndent),
-  }
-}
-
 /**
  * Insert comma at the last LineContent of its children
  * If it's the last content, no comma will be inserted
@@ -181,48 +140,35 @@ function removeFirstLineIndent<T extends NestedContent | LineContent>(
 function insertComma(
   content: LineContent | NestedContent,
   isLast: boolean,
-  indent = 0,
 ): LineContent | NestedContent {
   if (content.type === 'line') {
-    return insertCommaForLine(content, isLast, indent)
+    return insertCommaForLine(content, isLast)
   }
-  return insertCommaForNested(content, isLast, indent)
+  return insertCommaForNested(content, isLast)
 }
 
 function insertCommaForLine(
   content: LineContent,
   isLast: boolean,
-  indent = 0,
 ): LineContent {
-  if (isLast)
-    return {
-      ...content,
-      children: [createIndent(indent)!, ...(content.children ?? [])].filter(
-        Boolean,
-      ),
-    }
+  if (isLast) return content
 
   return {
     ...content,
-    children: [
-      createIndent(indent)!,
-      ...(content.children ?? []),
-      { text: ',' },
-    ].filter(Boolean),
+    children: [...(content.children ?? []), { text: ',' }],
   }
 }
 
 function insertCommaForNested(
   content: NestedContent,
   isLast: boolean,
-  indent = 0,
 ): NestedContent {
   if (isLast) return content
 
   return {
     ...content,
     children: content.children?.map((child, index, list) =>
-      index === list.length - 1 ? insertComma(child, false, indent) : child,
+      index === list.length - 1 ? insertComma(child, false) : child,
     ),
   }
 }
@@ -230,33 +176,26 @@ function insertCommaForNested(
 function arrangeObjectEntry(
   content: LineContent | NestedContent,
   keyContent: InlineContent,
-  indent = 0,
 ): LineContent | NestedContent {
   if (content.type === 'line') {
-    return arrangeObjectEntryForLine(content, keyContent, indent)
+    return arrangeObjectEntryForLine(content, keyContent)
   }
-  return arrangeObjectEntryForNested(content, keyContent, indent)
+  return arrangeObjectEntryForNested(content, keyContent)
 }
 
 function arrangeObjectEntryForLine(
   content: LineContent,
   keyContent: InlineContent,
-  indent = 0,
 ): LineContent {
   return {
     ...content,
-    children: [
-      createIndent(indent)!,
-      keyContent,
-      ...(content.children ?? []),
-    ].filter(Boolean),
+    children: [keyContent, ...(content.children ?? [])],
   }
 }
 
 function arrangeObjectEntryForNested(
   content: NestedContent,
   keyContent: InlineContent,
-  indent = 0,
 ): NestedContent {
   return {
     type: 'block',
@@ -273,11 +212,7 @@ function arrangeObjectEntryForNested(
             type: 'line',
             line: content.lineBegin,
             // currently children[0] must be bracket
-            children: [
-              createIndent(indent)!,
-              keyContent,
-              ...((child as LineContent).children ?? []),
-            ].filter(Boolean),
+            children: [keyContent, ...((child as LineContent).children ?? [])],
           }
         : child,
     ),
@@ -287,31 +222,18 @@ function arrangeObjectEntryForNested(
 function arrangeJsonRaw(
   data: any,
   offset = 0,
-  indent = 0,
 ): {
   content: LineContent | NestedContent
   nextOffset: number
 } {
   if (!data || typeof data !== 'object') {
     return {
-      content: {
-        type: 'line',
-        line: offset,
-        children: [arrangePrimitive(data)],
-      },
+      content: arrangePrimitive(data, offset),
       nextOffset: offset + 1,
     }
   }
   if (data instanceof Array) {
-    return arrangeArray(data, offset, indent)
+    return arrangeArray(data, offset)
   }
-  return arrangeObject(data, offset, indent)
-}
-
-function createIndent(indent: number): InlineContent | null {
-  if (!indent) return null
-
-  return {
-    text: ' '.repeat(indent * 2),
-  }
+  return arrangeObject(data, offset)
 }


### PR DESCRIPTION
# Related

- #9 
- #24 

# Details

- Revert #24 because it's too hard to handle folding using indent
- If there is an indent `InlineContent` in the children of `LineContent`, `JSONRenderer` is coupling with specific language spec too much. Because it's required to get rid of last line's indent to collapse multi line into single line.
- Since indentation rule differs with language, something should be injected via `Arranger`. But its priority goes low.

`i_love_collei`